### PR TITLE
fix: allow tabs and spaces to be used as indents

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const replacements = require('./replacements');
 function convert(input) {
   let output = input;
 
-  output = output.replace(/^([ ]*it\(['"])(.*)$/gm, (match, it, description) => {
+  output = output.replace(/^([ \t]*it\(['"])(.*)$/gm, (match, it, description) => {
 
     Object.keys(replacements).forEach(from => {
       const to = replacements[from];


### PR DESCRIPTION
Allow both spaces and tabs to be used to indent tests